### PR TITLE
ability to work with files from remote url

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,24 @@ console.log(stl.boundingBox,'(mm)');  // [60,45,50] (mm)
 ```
 node-stl recognizes by itself whether it is dealing with an ASCII STL or a binary STL file
 
+## load file from url
+
+Use `request` to load a file from url
+
+```javascript
+var request=require('request');
+var requestSettings = {
+   method: 'GET',
+   url: 'https://s3.amazonaws.com/minifactory-stl/WALLY_1plate.stl',
+   encoding: null,
+};
+request(requestSettings, function(error, response, body) {
+    var stl = new NodeStl(body);
+    assert.equal(stl.volume, 21.87511539650792);
+    done(null);
+});
+```
+
 ## install
 
 use [npm](https://npmjs.org):

--- a/index.js
+++ b/index.js
@@ -141,10 +141,13 @@ function _parseSTLBinary (buf) {
 // > console.log(stl.volume + 'cm^3');
 // > console.log(stl.weight + 'gm');
 function NodeStl (stlPath) {
-	var 
-	buf = fs.readFileSync(stlPath),
+	var buf;
+	if(Object.prototype.toString.call(stlPath)=='[object String]')
+		buf = fs.readFileSync(stlPath);
+	else if(Object.prototype.toString.call(stlPath)=='[object Uint8Array]')
+		buf=stlPath;
 	isAscii = true;
-	
+		
 	for (var i=0, len=buf.length; i<len; i++) {
 		if (buf[i] > 127) { isAscii=false; break; }
 	}

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "license": "MIT",
   "dependencies": {},
   "devDependencies": {
-    "mocha": "^2.5.3"
+    "mocha": "^2.5.3",
+    "request": "^2.81.0"
   }
 }

--- a/test/parse.js
+++ b/test/parse.js
@@ -1,6 +1,7 @@
 var 
 assert								= require('assert'),
 NodeStl								= require('../');
+request								= require('request');
 
 describe('should load an STL and measure volume and weight', function () {
 	it('load an ascii file', function() {
@@ -19,4 +20,22 @@ describe('should load an STL and measure volume and weight', function () {
     assert.deepEqual(c.boundingBox.map(function (bbe) { return Math.round(bbe) }), 
       [60,45,50])
 	});
+	it('loads a file buffer', function() {
+		var fs = require('fs');
+		var file_buf = fs.readFileSync(__dirname + '/test_data/WALLY_1plate.stl');
+		var a = new NodeStl(file_buf);
+		assert.equal(a.volume, 21.87511539650792);
+	});
+	it('loads a file from url',function(done){
+		var requestSettings = {
+		   method: 'GET',
+		   url: 'https://s3.amazonaws.com/minifactory-stl/WALLY_1plate.stl',
+		   encoding: null,
+		};
+		request(requestSettings, function(error, response, file) {
+			var a = new NodeStl(file);
+			assert.equal(a.volume, 21.87511539650792);
+			done(null);
+		});
+	}).timeout('5000');
 });


### PR DESCRIPTION
the library assumes that the file will be read from local directory. 

With this patch, the library can support remote urls. Need to use request to get the file object first.