### PR TITLE
fix bug: scientific notation in vertex

### DIFF
--- a/index.js
+++ b/index.js
@@ -95,7 +95,7 @@ function parseSTLString(stl) {
 			.forEach(function(vertex, i) {
 				let vector = vertex
 					.replace('vertex', '')
-					.match(/[-+]?[0-9]*\.?[0-9]+/g);
+					.match(/[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?/g);
 
 				triangle[i] = new Vector3(vector[0], vector[1], vector[2]);
 			});

--- a/test/parse.js
+++ b/test/parse.js
@@ -26,6 +26,12 @@ describe('should load an STL and measure volume, weight, and area', function () 
     		assert.equal(d.area, 52);
     		assert.equal(d.volume*1000, 24);
 	});
+	it('loads the box_3x3x3_offset with area of 54 and volume of 27', function() {
+		var d = new NodeStl(__dirname + '/test_data/box_3x3x3_offset.stl');
+    		assert.equal(d.area, 54);
+        // toPrecision because the calculation is off due to JS accuracy issues
+    		assert.equal(d.volume.toPrecision(6), 0.027);
+	});
 	it('loads a binary file that starts with solid', function() {
 	  // source for this stl: http://www.thingiverse.com/thing:2462372
 	  var e = new NodeStl(__dirname + '/test_data/002.STL');

--- a/test/test_data/box_3x3x3_offset.stl
+++ b/test/test_data/box_3x3x3_offset.stl
@@ -1,0 +1,86 @@
+solid OpenSCAD_Model
+  facet normal -0 0 1
+    outer loop
+      vertex 1e-05 3 3
+      vertex 3.00001 0 3
+      vertex 3.00001 3 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 3.00001 0 3
+      vertex 1e-05 3 3
+      vertex 1e-05 0 3
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1e-05 0 0
+      vertex 3.00001 3 0
+      vertex 3.00001 0 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 3.00001 3 0
+      vertex 1e-05 0 0
+      vertex 1e-05 3 0
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 1e-05 0 0
+      vertex 3.00001 0 3
+      vertex 1e-05 0 3
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 3.00001 0 3
+      vertex 1e-05 0 0
+      vertex 3.00001 0 0
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex 3.00001 0 3
+      vertex 3.00001 3 0
+      vertex 3.00001 3 3
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 3.00001 3 0
+      vertex 3.00001 0 3
+      vertex 3.00001 0 0
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 3.00001 3 0
+      vertex 1e-05 3 3
+      vertex 3.00001 3 3
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 1e-05 3 3
+      vertex 3.00001 3 0
+      vertex 1e-05 3 0
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 1e-05 0 0
+      vertex 1e-05 3 3
+      vertex 1e-05 3 0
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex 1e-05 3 3
+      vertex 1e-05 0 0
+      vertex 1e-05 0 3
+    endloop
+  endfacet
+endsolid OpenSCAD_Model


### PR DESCRIPTION
Hi, it seems the code has a little but triggered by the presence of scientific notation in vertex coordinates in text STL:

`vertex 1e-05 0 0` is parsed as `Vector3 { x: '1', y: '-05', z: '0' }`

This PR adds a test that illustrates this issue, and fixes it.

Other tests fail, probably because they actually expect the wrong outputs, but please correct me if I'm wrong.