### PR TITLE
implement computation of center of mass

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 node-stl
 ========
 
-Parse *STL* files with Node.js and get volume, weight, and the bounding box.
+Parse *STL* files with Node.js and get volume, weight, the bounding box, and the center of mass.
 
 ## example
 
@@ -11,6 +11,7 @@ console.log(stl.volume + 'cm^3');     // 21cm^3
 console.log(stl.weight + 'gm');       //  1gm
 console.log(stl.boundingBox,'(mm)');  // [60,45,50] (mm)
 console.log(stl.area,'(m)');          // 91.26 (m)
+console.log(stl.centerOfMass,'(mm)'); // [30,22.5,25] (mm)
 ```
 node-stl recognizes by itself whether it is dealing with an ASCII STL or a binary STL file
 

--- a/index.js
+++ b/index.js
@@ -65,8 +65,8 @@ class STLMeasures {
 		this.maxy = -Infinity;
 		this.minz = Infinity;
 		this.maxz = -Infinity;
-		this.xCenter = 0,
-		this.yCenter = 0,
+		this.xCenter = 0;
+		this.yCenter = 0;
 		this.zCenter = 0;
 	}
 

--- a/index.js
+++ b/index.js
@@ -56,23 +56,23 @@ class Vector3 {
 }
 
 class STLMeasures {
-  constructor() {
-  	this.volume = 0;
-  	this.area = 0;
-  	this.minx = Infinity;
-  	this.maxx = -Infinity;
-  	this.miny = Infinity;
-  	this.maxy = -Infinity;
-  	this.minz = Infinity;
-  	this.maxz = -Infinity;
-    this.xCenter = 0,
-    this.yCenter = 0,
-    this.zCenter = 0;
-  }
+	constructor() {
+		this.volume = 0;
+		this.area = 0;
+		this.minx = Infinity;
+		this.maxx = -Infinity;
+		this.miny = Infinity;
+		this.maxy = -Infinity;
+		this.minz = Infinity;
+		this.maxz = -Infinity;
+		this.xCenter = 0,
+		this.yCenter = 0,
+		this.zCenter = 0;
+	}
 
-  addTriangle(triangle) {
-    let currentVolume = _triangleVolume(triangle);
- 		this.volume += currentVolume;
+	addTriangle(triangle) {
+		let currentVolume = _triangleVolume(triangle);
+		this.volume += currentVolume;
 
 		const ab = triangle[1].clone().sub(triangle[0]);
 		const ac = triangle[2].clone().sub(triangle[0]);
@@ -98,28 +98,28 @@ class STLMeasures {
 		const tmaxz = Math.max(triangle[0].z, triangle[1].z, triangle[2].z);
 		this.maxz = tmaxz > this.maxz ? tmaxz : this.maxz;
 
-    // Center of Mass calculation
-    // adapted from c++ at: https://stackoverflow.com/a/2085502/6482703
-    this.xCenter += ((triangle[0].x + triangle[1].x + triangle[2].x) / 4) * currentVolume;
-    this.yCenter += ((triangle[0].y + triangle[1].y + triangle[2].y) / 4) * currentVolume;
-    this.zCenter += ((triangle[0].z + triangle[1].z + triangle[2].z) / 4) * currentVolume;
-  }
+		// Center of Mass calculation
+		// adapted from c++ at: https://stackoverflow.com/a/2085502/6482703
+		this.xCenter += ((triangle[0].x + triangle[1].x + triangle[2].x) / 4) * currentVolume;
+		this.yCenter += ((triangle[0].y + triangle[1].y + triangle[2].y) / 4) * currentVolume;
+		this.zCenter += ((triangle[0].z + triangle[1].z + triangle[2].z) / 4) * currentVolume;
+	}
 
-  finalize() {
-  	const volumeTotal = Math.abs(this.volume) / 1000;
+	finalize() {
+		const volumeTotal = Math.abs(this.volume) / 1000;
 
-    this.xCenter /= this.volume;
-    this.yCenter /= this.volume;
-    this.zCenter /= this.volume;
+		this.xCenter /= this.volume;
+		this.yCenter /= this.volume;
+		this.zCenter /= this.volume;
 
-  	return {
-  		volume: volumeTotal, // cubic cm
-  		weight: volumeTotal * 1.04, // gm
-  		boundingBox: [this.maxx - this.minx, this.maxy - this.miny, this.maxz - this.minz],
-  		area: this.area,
-      centerOfMass: [this.xCenter, this.yCenter, this.zCenter],
-  	};
-  }
+		return {
+			volume: volumeTotal, // cubic cm
+			weight: volumeTotal * 1.04, // gm
+			boundingBox: [this.maxx - this.minx, this.maxy - this.miny, this.maxz - this.minz],
+			area: this.area,
+			centerOfMass: [this.xCenter, this.yCenter, this.zCenter],
+		};
+	}
 }
 
 // calculation of the triangle volume
@@ -143,7 +143,7 @@ function parseSTLString(stl) {
 		/facet\s+normal\s+([-+]?\b(?:[0-9]*\.)?[0-9]+(?:[eE][-+]?[0-9]+)?\b)\s+([-+]?\b(?:[0-9]*\.)?[0-9]+(?:[eE][-+]?[0-9]+)?\b)\s+([-+]?\b(?:[0-9]*\.)?[0-9]+(?:[eE][-+]?[0-9]+)?\b)\s+outer\s+loop\s+vertex\s+([-+]?\b(?:[0-9]*\.)?[0-9]+(?:[eE][-+]?[0-9]+)?\b)\s+([-+]?\b(?:[0-9]*\.)?[0-9]+(?:[eE][-+]?[0-9]+)?\b)\s+([-+]?\b(?:[0-9]*\.)?[0-9]+(?:[eE][-+]?[0-9]+)?\b)\s+vertex\s+([-+]?\b(?:[0-9]*\.)?[0-9]+(?:[eE][-+]?[0-9]+)?\b)\s+([-+]?\b(?:[0-9]*\.)?[0-9]+(?:[eE][-+]?[0-9]+)?\b)\s+([-+]?\b(?:[0-9]*\.)?[0-9]+(?:[eE][-+]?[0-9]+)?\b)\s+vertex\s+([-+]?\b(?:[0-9]*\.)?[0-9]+(?:[eE][-+]?[0-9]+)?\b)\s+([-+]?\b(?:[0-9]*\.)?[0-9]+(?:[eE][-+]?[0-9]+)?\b)\s+([-+]?\b(?:[0-9]*\.)?[0-9]+(?:[eE][-+]?[0-9]+)?\b)\s+endloop\s+endfacet/g
 	);
 
-  let measures = new STLMeasures();
+	let measures = new STLMeasures();
 
 	vertexes.forEach(function(vert) {
 		const triangle = new Array(3);
@@ -159,10 +159,10 @@ function parseSTLString(stl) {
 				triangle[i] = new Vector3(vector[0], vector[1], vector[2]);
 			});
 
-      measures.addTriangle(triangle);
+			measures.addTriangle(triangle);
 	});
 
-  return measures.finalize();
+	return measures.finalize();
 }
 
 // parsing an STL Binary File
@@ -172,7 +172,7 @@ const parseSTLBinary = function(buffer) {
 	const dataOffset = 84;
 	const faceLength = 12 * 4 + 2;
 
-  let measures = new STLMeasures();
+	let measures = new STLMeasures();
 
 	for (let face = 0; face < faces; face++) {
 		const start = dataOffset + face * faceLength;
@@ -189,10 +189,10 @@ const parseSTLBinary = function(buffer) {
 			);
 		}
 
-    measures.addTriangle(triangle);
+		measures.addTriangle(triangle);
 	}
 
-  return measures.finalize();
+	return measures.finalize();
 };
 
 // check if stl is binary vs ASCII

--- a/index.js
+++ b/index.js
@@ -55,6 +55,57 @@ class Vector3 {
 	}
 }
 
+class STLMeasures {
+  constructor() {
+  	this.volume = 0;
+  	this.area = 0;
+  	this.minx = Infinity;
+  	this.maxx = -Infinity;
+  	this.miny = Infinity;
+  	this.maxy = -Infinity;
+  	this.minz = Infinity;
+  	this.maxz = -Infinity;
+  }
+
+  addTriangle(triangle) {
+ 		this.volume += _triangleVolume(triangle);
+
+		const ab = triangle[1].clone().sub(triangle[0]);
+		const ac = triangle[2].clone().sub(triangle[0]);
+
+		this.area +=
+			ab
+				.clone()
+				.cross(ac)
+				.length() / 2;
+
+		const tminx = Math.min(triangle[0].x, triangle[1].x, triangle[2].x);
+		this.minx = tminx < this.minx ? tminx : this.minx;
+		const tmaxx = Math.max(triangle[0].x, triangle[1].x, triangle[2].x);
+		this.maxx = tmaxx > this.maxx ? tmaxx : this.maxx;
+
+		const tminy = Math.min(triangle[0].y, triangle[1].y, triangle[2].y);
+		this.miny = tminy < this.miny ? tminy : this.miny;
+		const tmaxy = Math.max(triangle[0].y, triangle[1].y, triangle[2].y);
+		this.maxy = tmaxy > this.maxy ? tmaxy : this.maxy;
+
+		const tminz = Math.min(triangle[0].z, triangle[1].z, triangle[2].z);
+		this.minz = tminz < this.minz ? tminz : this.minz;
+		const tmaxz = Math.max(triangle[0].z, triangle[1].z, triangle[2].z);
+		this.maxz = tmaxz > this.maxz ? tmaxz : this.maxz;
+  }
+
+  finalize() {
+  	const volumeTotal = Math.abs(this.volume) / 1000;
+  	return {
+  		volume: volumeTotal, // cubic cm
+  		weight: volumeTotal * 1.04, // gm
+  		boundingBox: [this.maxx - this.minx, this.maxy - this.miny, this.maxz - this.minz],
+  		area: this.area
+  	};
+  }
+}
+
 // calculation of the triangle volume
 // source: http://stackoverflow.com/questions/6518404/how-do-i-calculate-the-volume-of-an-object-stored-in-stl-files
 function _triangleVolume(triangle) {
@@ -70,24 +121,16 @@ function _triangleVolume(triangle) {
 
 // parsing an STL ASCII string
 function parseSTLString(stl) {
-	let volume = 0;
-	let area = 0;
-	let minx = Infinity,
-		maxx = -Infinity,
-		miny = Infinity,
-		maxy = -Infinity,
-		minz = Infinity,
-		maxz = -Infinity;
-
 	// yes, this is the regular expression, matching the vertexes
 	// it was kind of tricky but it is fast and does the job
 	let vertexes = stl.match(
 		/facet\s+normal\s+([-+]?\b(?:[0-9]*\.)?[0-9]+(?:[eE][-+]?[0-9]+)?\b)\s+([-+]?\b(?:[0-9]*\.)?[0-9]+(?:[eE][-+]?[0-9]+)?\b)\s+([-+]?\b(?:[0-9]*\.)?[0-9]+(?:[eE][-+]?[0-9]+)?\b)\s+outer\s+loop\s+vertex\s+([-+]?\b(?:[0-9]*\.)?[0-9]+(?:[eE][-+]?[0-9]+)?\b)\s+([-+]?\b(?:[0-9]*\.)?[0-9]+(?:[eE][-+]?[0-9]+)?\b)\s+([-+]?\b(?:[0-9]*\.)?[0-9]+(?:[eE][-+]?[0-9]+)?\b)\s+vertex\s+([-+]?\b(?:[0-9]*\.)?[0-9]+(?:[eE][-+]?[0-9]+)?\b)\s+([-+]?\b(?:[0-9]*\.)?[0-9]+(?:[eE][-+]?[0-9]+)?\b)\s+([-+]?\b(?:[0-9]*\.)?[0-9]+(?:[eE][-+]?[0-9]+)?\b)\s+vertex\s+([-+]?\b(?:[0-9]*\.)?[0-9]+(?:[eE][-+]?[0-9]+)?\b)\s+([-+]?\b(?:[0-9]*\.)?[0-9]+(?:[eE][-+]?[0-9]+)?\b)\s+([-+]?\b(?:[0-9]*\.)?[0-9]+(?:[eE][-+]?[0-9]+)?\b)\s+endloop\s+endfacet/g
 	);
 
-	let triangle;
+  let measures = new STLMeasures();
+
 	vertexes.forEach(function(vert) {
-		triangle = new Array(3);
+		const triangle = new Array(3);
 		vert
 			.match(
 				/vertex\s+([-+]?\b(?:[0-9]*\.)?[0-9]+(?:[eE][-+]?[0-9]+)?\b)\s+([-+]?\b(?:[0-9]*\.)?[0-9]+(?:[eE][-+]?[0-9]+)?\b)\s+([-+]?\b(?:[0-9]*\.)?[0-9]+(?:[eE][-+]?[0-9]+)?\b)\s/g
@@ -100,40 +143,10 @@ function parseSTLString(stl) {
 				triangle[i] = new Vector3(vector[0], vector[1], vector[2]);
 			});
 
-		volume += _triangleVolume(triangle);
-
-		const ab = triangle[1].clone().sub(triangle[0]);
-		const ac = triangle[2].clone().sub(triangle[0]);
-
-		area +=
-			ab
-				.clone()
-				.cross(ac)
-				.length() / 2;
-
-		const tminx = Math.min(triangle[0].x, triangle[1].x, triangle[2].x);
-		minx = tminx < minx ? tminx : minx;
-		const tmaxx = Math.max(triangle[0].x, triangle[1].x, triangle[2].x);
-		maxx = tmaxx > maxx ? tmaxx : maxx;
-
-		const tminy = Math.min(triangle[0].y, triangle[1].y, triangle[2].y);
-		miny = tminy < miny ? tminy : miny;
-		const tmaxy = Math.max(triangle[0].y, triangle[1].y, triangle[2].y);
-		maxy = tmaxy > maxy ? tmaxy : maxy;
-
-		const tminz = Math.min(triangle[0].z, triangle[1].z, triangle[2].z);
-		minz = tminz < minz ? tminz : minz;
-		const tmaxz = Math.max(triangle[0].z, triangle[1].z, triangle[2].z);
-		maxz = tmaxz > maxz ? tmaxz : maxz;
+      measures.addTriangle(triangle);
 	});
 
-	let volumeTotal = Math.abs(volume) / 1000;
-	return {
-		volume: volumeTotal, // cubic cm
-		weight: volumeTotal * 1.04, // gm
-		boundingBox: [maxx - minx, maxy - miny, maxz - minz],
-		area: area
-	};
+  return measures.finalize();
 }
 
 // parsing an STL Binary File
@@ -143,14 +156,7 @@ const parseSTLBinary = function(buffer) {
 	const dataOffset = 84;
 	const faceLength = 12 * 4 + 2;
 
-	let volume = 0;
-	let area = 0;
-	let minx = Infinity,
-		maxx = -Infinity,
-		miny = Infinity,
-		maxy = -Infinity,
-		minz = Infinity,
-		maxz = -Infinity;
+  let measures = new STLMeasures();
 
 	for (let face = 0; face < faces; face++) {
 		const start = dataOffset + face * faceLength;
@@ -167,40 +173,10 @@ const parseSTLBinary = function(buffer) {
 			);
 		}
 
-		volume += _triangleVolume(triangle);
-
-		const ab = triangle[1].clone().sub(triangle[0]);
-		const ac = triangle[2].clone().sub(triangle[0]);
-
-		area +=
-			ab
-				.clone()
-				.cross(ac)
-				.length() / 2;
-
-		const tminx = Math.min(triangle[0].x, triangle[1].x, triangle[2].x);
-		minx = tminx < minx ? tminx : minx;
-		const tmaxx = Math.max(triangle[0].x, triangle[1].x, triangle[2].x);
-		maxx = tmaxx > maxx ? tmaxx : maxx;
-
-		const tminy = Math.min(triangle[0].y, triangle[1].y, triangle[2].y);
-		miny = tminy < miny ? tminy : miny;
-		const tmaxy = Math.max(triangle[0].y, triangle[1].y, triangle[2].y);
-		maxy = tmaxy > maxy ? tmaxy : maxy;
-
-		const tminz = Math.min(triangle[0].z, triangle[1].z, triangle[2].z);
-		minz = tminz < minz ? tminz : minz;
-		const tmaxz = Math.max(triangle[0].z, triangle[1].z, triangle[2].z);
-		maxz = tmaxz > maxz ? tmaxz : maxz;
+    measures.addTriangle(triangle);
 	}
 
-	volume = Math.abs(volume) / 1000;
-	return {
-		volume: volume, // cubic cm
-		weight: volume * 1.04, // gm
-		boundingBox: [maxx - minx, maxy - miny, maxz - minz],
-		area: area
-	};
+  return measures.finalize();
 };
 
 // check if stl is binary vs ASCII

--- a/index.js
+++ b/index.js
@@ -3,9 +3,9 @@ var fs = require('fs');
 // 3d Vector x,y,z
 class Vector3 {
 	constructor(x, y, z) {
-		this.x = x;
-		this.y = y;
-		this.z = z;
+		this.x = Number(x);
+		this.y = Number(y);
+		this.z = Number(z);
 	}
 
 	// Create a copy of the Vector
@@ -65,10 +65,14 @@ class STLMeasures {
   	this.maxy = -Infinity;
   	this.minz = Infinity;
   	this.maxz = -Infinity;
+    this.xCenter = 0,
+    this.yCenter = 0,
+    this.zCenter = 0;
   }
 
   addTriangle(triangle) {
- 		this.volume += _triangleVolume(triangle);
+    let currentVolume = _triangleVolume(triangle);
+ 		this.volume += currentVolume;
 
 		const ab = triangle[1].clone().sub(triangle[0]);
 		const ac = triangle[2].clone().sub(triangle[0]);
@@ -93,15 +97,25 @@ class STLMeasures {
 		this.minz = tminz < this.minz ? tminz : this.minz;
 		const tmaxz = Math.max(triangle[0].z, triangle[1].z, triangle[2].z);
 		this.maxz = tmaxz > this.maxz ? tmaxz : this.maxz;
+
+    this.xCenter += ((triangle[0].x + triangle[1].x + triangle[2].x) / 4) * currentVolume;
+    this.yCenter += ((triangle[0].y + triangle[1].y + triangle[2].y) / 4) * currentVolume;
+    this.zCenter += ((triangle[0].z + triangle[1].z + triangle[2].z) / 4) * currentVolume;
   }
 
   finalize() {
   	const volumeTotal = Math.abs(this.volume) / 1000;
+
+    this.xCenter /= this.volume;
+    this.yCenter /= this.volume;
+    this.zCenter /= this.volume;
+
   	return {
   		volume: volumeTotal, // cubic cm
   		weight: volumeTotal * 1.04, // gm
   		boundingBox: [this.maxx - this.minx, this.maxy - this.miny, this.maxz - this.minz],
-  		area: this.area
+  		area: this.area,
+      centerOfMass: [this.xCenter, this.yCenter, this.zCenter],
   	};
   }
 }

--- a/index.js
+++ b/index.js
@@ -98,6 +98,8 @@ class STLMeasures {
 		const tmaxz = Math.max(triangle[0].z, triangle[1].z, triangle[2].z);
 		this.maxz = tmaxz > this.maxz ? tmaxz : this.maxz;
 
+    // Center of Mass calculation
+    // adapted from c++ at: https://stackoverflow.com/a/2085502/6482703
     this.xCenter += ((triangle[0].x + triangle[1].x + triangle[2].x) / 4) * currentVolume;
     this.yCenter += ((triangle[0].y + triangle[1].y + triangle[2].y) / 4) * currentVolume;
     this.zCenter += ((triangle[0].z + triangle[1].z + triangle[2].z) / 4) * currentVolume;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "node-stl",
   "version": "0.5.1",
-  "description": "parse stl files with Node.js and get volume, weight, and bounding box",
+  "description": "parse stl files with Node.js and get volume, weight, bounding box, and center of mass",
   "contributors": [
     {
       "name": "Alex J Vazhatharayil",

--- a/test/parse.js
+++ b/test/parse.js
@@ -25,12 +25,15 @@ describe('should load an STL and measure volume, weight, and area', function () 
 		var d = new NodeStl(__dirname + '/test_data/box_2x3x4.stl');
 		assert.equal(d.area, 52);
 		assert.equal(d.volume*1000, 24);
+		assert.deepEqual(d.centerOfMass, [0,0,0]);
 	});
 	it('loads the box_3x3x3_offset with area of 54 and volume of 27', function() {
 		var d = new NodeStl(__dirname + '/test_data/box_3x3x3_offset.stl');
 		assert.equal(d.area, 54);
     // toPrecision because the calculation is off due to JS accuracy issues
 		assert.equal(d.volume.toPrecision(6), 0.027);
+		assert.deepEqual(d.centerOfMass.map(function (x) {return Number(x.toPrecision(6))}),
+      [1.50001,1.5,1.5]);
 	});
 	it('loads a binary file that starts with solid', function() {
 	  // source for this stl: http://www.thingiverse.com/thing:2462372

--- a/test/parse.js
+++ b/test/parse.js
@@ -23,14 +23,14 @@ describe('should load an STL and measure volume, weight, and area', function () 
 	it('loads the box_2x3x4 with area of 52 and volume of 24', function() {
 		// source for this stl: http://www.thingiverse.com/thing:1607628
 		var d = new NodeStl(__dirname + '/test_data/box_2x3x4.stl');
-    		assert.equal(d.area, 52);
-    		assert.equal(d.volume*1000, 24);
+		assert.equal(d.area, 52);
+		assert.equal(d.volume*1000, 24);
 	});
 	it('loads the box_3x3x3_offset with area of 54 and volume of 27', function() {
 		var d = new NodeStl(__dirname + '/test_data/box_3x3x3_offset.stl');
-    		assert.equal(d.area, 54);
-        // toPrecision because the calculation is off due to JS accuracy issues
-    		assert.equal(d.volume.toPrecision(6), 0.027);
+		assert.equal(d.area, 54);
+    // toPrecision because the calculation is off due to JS accuracy issues
+		assert.equal(d.volume.toPrecision(6), 0.027);
 	});
 	it('loads a binary file that starts with solid', function() {
 	  // source for this stl: http://www.thingiverse.com/thing:2462372

--- a/test/parse.js
+++ b/test/parse.js
@@ -7,7 +7,7 @@ describe('should load an STL and measure volume, weight, and area', function () 
 	it('load an ascii file', function() {
 		// source for this stl: http://www.thingiverse.com/thing:47956
 		var a = new NodeStl(__dirname + '/test_data/WALLY_1plate.stl');
-		assert.equal(a.volume, 21.87511539650792);
+		assert.equal(a.volume, 22.86382329248822);
 	});
 	it('load a binary file', function() {
 		// source for this stl: http://www.thingiverse.com/thing:61532
@@ -41,7 +41,7 @@ describe('should load an STL and measure volume, weight, and area', function () 
 		var fs = require('fs');
 		var file_buf = fs.readFileSync(__dirname + '/test_data/WALLY_1plate.stl');
 		var a = new NodeStl(file_buf);
-		assert.equal(a.volume, 21.87511539650792);
+		assert.equal(a.volume, 22.86382329248822);
 	});
 	it('loads a file from url',function(done){
 		var requestSettings = {
@@ -51,7 +51,7 @@ describe('should load an STL and measure volume, weight, and area', function () 
 		};
 		request(requestSettings, function(error, response, file) {
 			var a = new NodeStl(file);
-			assert.equal(a.volume, 21.87511539650792);
+			assert.equal(a.volume, 22.86382329248822);
 			done(null);
 		});
 	}).timeout('5000');


### PR DESCRIPTION
Hi again, I needed to compute the center of mass of some models, and `node-stl` was a good starting point. Here's a PR, if you like it.

It's probably best reviewed commit-by-commit:
1. it fix the tests that were failing after #8 
2. it refactors the code to remove duplication of processing code between binary and text STLs
3. (just whitespace, sorry if I use the wrong spaces or tabs)
4. the actual addition of center-of-mass computation, adapted from https://stackoverflow.com/a/2085502/6482703